### PR TITLE
[Tests] migrate tests to Github Actions

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 test/fixtures/**
+coverage/

--- a/.github/workflows/node-pretest.yml
+++ b/.github/workflows/node-pretest.yml
@@ -1,0 +1,26 @@
+name: 'Tests: pretest/posttest'
+
+on: [pull_request, push]
+
+jobs:
+  pretest:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ljharb/actions/node/run@main
+        name: 'npm install && npm run pretest'
+        with:
+          node-version: 'lts/*'
+          command: 'pretest'
+
+  posttest:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ljharb/actions/node/run@main
+        name: 'npm install && npm run posttest'
+        with:
+          node-version: 'lts/*'
+          command: 'posttest'

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -1,0 +1,55 @@
+name: 'Tests: node.js'
+
+on: [pull_request, push]
+
+jobs:
+  matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      latest: ${{ steps.set-matrix.outputs.requireds }}
+      minors: ${{ steps.set-matrix.outputs.optionals }}
+    steps:
+      - uses: ljharb/actions/node/matrix@main
+        id: set-matrix
+        with:
+          preset: '>=10'
+
+  latest:
+    needs: [matrix]
+    name: 'latest minors'
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix: ${{ fromJson(needs.matrix.outputs.latest) }}
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ljharb/actions/node/run@main
+        name: 'npm install && npm run tests-only'
+        with:
+          node-version: ${{ matrix.node-version }}
+          command: 'tests-only'
+  minors:
+    needs: [matrix, latest]
+    name: 'non-latest minors'
+    continue-on-error: true
+    if: ${{ !github.head_ref || !startsWith(github.head_ref, 'renovate') }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix: ${{ fromJson(needs.matrix.outputs.minors) }}
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ljharb/actions/node/run@main
+        name: 'npm install && npm run tests-only'
+        with:
+          node-version: ${{ matrix.node-version }}
+          command: 'tests-only'
+
+  node:
+    name: 'node'
+    needs: [latest, minors]
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo tests completed'

--- a/.nycrc
+++ b/.nycrc
@@ -1,0 +1,13 @@
+{
+	"all": true,
+	"check-coverage": false,
+	"reporter": ["text-summary", "text", "html", "json"],
+	"lines": 86,
+	"statements": 85.93,
+	"functions": 82.43,
+	"branches": 76.06,
+	"exclude": [
+		"coverage",
+		"test"
+	]
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-version: ~> 1.0
-language: node_js
-os:
- - linux
-import:
- - ljharb/travis-ci:node/minors/gte_10.yml
- - ljharb/travis-ci:node/pretest.yml
- - ljharb/travis-ci:node/posttest.yml

--- a/bin/ls-engines
+++ b/bin/ls-engines
@@ -84,7 +84,7 @@ const pPackage = jsonFile(path.join(process.cwd(), 'package.json'));
 
 const graphRanges = getTree(mode, { dev, production }).then(async (tree) => {
 	const graph = Array.from(
-		tree.inventory.filter(({ package: { engines } }) => engines && engines.node),
+		tree.inventory.filter(({ package: { engines }, edgesIn }) => edgesIn.size > 0 && engines && engines.node),
 		({ name, package: { engines: { node } } }) => node && [name, node],
 	).filter(([, node] = []) => node && node !== '*');
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
 		"npm": ">=6"
 	},
 	"dependencies": {
-		"@npmcli/arborist": "^1.0.14",
+		"@npmcli/arborist": "^2.2.2",
 		"chalk": "^4.1.0",
 		"fast_array_intersect": "^1.1.0",
 		"get-json": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 	"scripts": {
 		"lint": "eslint . bin/*",
 		"pretest": "npm run lint",
-		"tests-only": "tape test",
+		"tests-only": "nyc tape 'test/*.js'",
 		"test": "npm run tests-only",
 		"posttest": "npx aud --production",
 		"version": "auto-changelog && git add CHANGELOG.md",
@@ -52,6 +52,7 @@
 		"aud": "^1.1.4",
 		"auto-changelog": "^2.2.1",
 		"eslint": "^7.20.0",
+		"nyc": "^15.1.0",
 		"tape": "^5.1.1"
 	},
 	"auto-changelog": {


### PR DESCRIPTION
Per https://github.com/ljharb/object.assign/pull/81
> travis-ci's new pricing plan, and its defaults, have caused all my `ljharb` repos to have zero CI whatsoever until December. @travis-ci Support is MIA, so I unfortunately can't rely on it as a service anymore.