### PR TITLE
Bump `@npmcli/arborist` and `pacote`

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,11 +38,11 @@
 	},
 	"homepage": "https://github.com/ljharb/ls-engines#readme",
 	"engines": {
-		"node": ">= 19 || ^18 || ^16.13 || ^14.18",
+		"node": ">= 19 || ^18 || ^16.14",
 		"npm": ">=8"
 	},
 	"dependencies": {
-		"@npmcli/arborist": "^6.5.1",
+		"@npmcli/arborist": "^7.2.1",
 		"array.prototype.some": "^1.1.6",
 		"array.prototype.tosorted": "^1.1.4",
 		"colors": "=1.4.0",
@@ -54,7 +54,7 @@
 		"object.fromentries": "^2.0.8",
 		"object.groupby": "^1.0.3",
 		"object.values": "^1.2.0",
-		"pacote": "^15.2.0",
+		"pacote": "^18.0.6",
 		"promise.allsettled": "^1.0.7",
 		"semver": "^7.6.3",
 		"table": "^6.8.2",


### PR DESCRIPTION
Upgrade `@npmcli/arborist` and `pacote` to newer versions in order to resolve 13 deprecation warnings. This comes at the cost of dropping support for Node.js `^14.18` and `=16.13`. These are the minimum (major version) upgrades necessary to achieve this goal.

Note: some of the deprecation warnings are still present due to the dependency on [`get-dep-tree`](https://github.com/ljharb/get-dep-tree), to resolve these too it would need to receive similar upgrades. Since you're maintaining both of these packages I figured I can start with one PR and see if you're open to upgrading :slightly_smiling_face: